### PR TITLE
Update coffeescript package to fix deprecation warnings

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,8 @@
+# 0.1.4
+
+* Upgraded to CoffeeScript 2.4.1
+
+
 # 0.1.3 / 2015-02-19
 
 * Upgraded to CoffeeScript 1.9.1

--- a/package.json
+++ b/package.json
@@ -5,14 +5,14 @@
   "version": "0.1.2",
   "main": "./wrapper.js",
   "repository": {
-    "type" : "git",
+    "type": "git",
     "url": "https://github.com/socketstream/ss-coffee.git"
   },
   "engines": {
     "node": ">= 0.10.32"
   },
   "dependencies": {
-    "coffee-script": "1.9.1"
+    "coffeescript": "^2.4.1"
   },
   "devDependencies": {}
 }

--- a/wrapper.js
+++ b/wrapper.js
@@ -1,9 +1,11 @@
-// CoffeeScript (JS) wrapper for SocketStream 0.3
+// CoffeeScript (JS) wrapper for SocketStream 0.3 and 0.4.x
 
 var fs = require('fs'),
-    coffee = require('coffee-script');
+    coffee = require('coffeescript');
 
 exports.init = function(root, config) {
+
+  coffee.register();
 
   return {
 


### PR DESCRIPTION
This is a part of a larger work:

See https://github.com/socketstream/socketstream/issues/619